### PR TITLE
[OpenGLES] OpenTK app + Intent.CreateChooser() crashes

### DIFF
--- a/Source/OpenTK/Platform/Android/AndroidGraphicsContext.cs
+++ b/Source/OpenTK/Platform/Android/AndroidGraphicsContext.cs
@@ -379,6 +379,7 @@ namespace OpenTK.Platform.Android {
 			if (eglSurface != EGL10.EglNoSurface) {
 				IEGL10 egl = EGLContext.EGL.JavaCast<IEGL10> ();
 				try	{
+					egl.EglMakeCurrent (eglDisplay, EGL10.EglNoSurface, EGL10.EglNoSurface, EGL10.EglNoContext);
 					if (!egl.EglDestroySurface (eglDisplay, eglSurface))
 						Log.Warn ("AndroidWindow", "Failed to destroy surface {0}.", eglSurface);
 				}


### PR DESCRIPTION
Fixes https://bugzilla.xamarin.com/show_bug.cgi?id=8182

Turns out the issue with this particular bug
was that we did not clear down the current context
prior to shutting down the activity/pausing. This left
OpenGL in some kind of weird state where it could not
use the surface and context current again until the
activity was destroyed.
