### PR TITLE
[quaternion] Fix obsolete attribute's message

### DIFF
--- a/Source/OpenTK/Math/Quaternion.cs
+++ b/Source/OpenTK/Math/Quaternion.cs
@@ -373,7 +373,7 @@ namespace OpenTK
             result = new Quaternion(quaternion.X * scale, quaternion.Y * scale, quaternion.Z * scale, quaternion.W * scale);
         }
 
-        [Obsolete ("Use the overload without the ref float scale")]
+        [Obsolete ("Use the overload without the 'ref float scale'.")]
         public static void Multiply(ref Quaternion quaternion, ref float scale, out Quaternion result)
         {
             result = new Quaternion(quaternion.X * scale, quaternion.Y * scale, quaternion.Z * scale, quaternion.W * scale);    


### PR DESCRIPTION
Our introspection tests now assert that availability attributes
follow precise rules: https://github.com/xamarin/xamarin-macios/wiki/BINDINGS#availability-attributes-messages