### PR TITLE
Create Xamarin.Legacy.OpenTK Nuget Package

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 *.userprefs
 obj
 bin
+*.nupkg
+*.snupkg

--- a/OpenTK.props
+++ b/OpenTK.props
@@ -1,0 +1,5 @@
+<Project>
+    <PropertyGroup>
+        <_OpenTKNugetVersion>0.0.1-alpha</_OpenTKNugetVersion>
+    </PropertyGroup>
+</Project>

--- a/Projects/OpenTK.Android/OpenTK.Android.csproj
+++ b/Projects/OpenTK.Android/OpenTK.Android.csproj
@@ -1,7 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Xamarin.Legacy.Sdk">
+  <Import Project="$(MSBuildThisFileDirectory)..\..\OpenTK.props" />
   <PropertyGroup>
-    <AssemblyName>OpenTK1.0</AssemblyName>
+    <AssemblyName>OpenTK-1.0</AssemblyName>
     <TargetFrameworks>monoandroid11.0;net6.0-android</TargetFrameworks>
     <AssemblyOriginatorKeyFile>..\..\OpenTK.snk</AssemblyOriginatorKeyFile>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
@@ -52,5 +53,26 @@
   <ItemGroup>
     <PackageReference Include="System.Drawing.Common" Version="*" Condition="$(TargetFramework.Contains ('ios'))"  />
   </ItemGroup>
+
+  <PropertyGroup>
+        <!--
+        nuget packaging
+        -->
+        <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
+        <PackageId>Xamarin.Legacy.OpenTK</PackageId>
+        <PackageVersion>$(_OpenTKNugetVersion)</PackageVersion>
+        <Title>Xamarin.Legacy.OpenTK</Title>
+        <Summary>Legacy OpenGL, OpenCL and OpenAL Bindings for Xamarin. (https://github.com/mono/opentk)</Summary>
+        <Description>Legacy OpenGL, OpenCL and OpenAL Bindings for Xamarin. (https://github.com/mono/opentk)</Description>
+        <Authors>Microsoft</Authors>
+        <Owners>Microsoft, Xamarin</Owners>
+        <Copyright>© Microsoft Corporation. All rights reserved.</Copyright>
+        <PackageProjectUrl>https://github.com/mono/opentk</PackageProjectUrl>
+        <PackageLicenseUrl>https://raw.githubusercontent.com/mono/opentk/main/Documentation/License.txt</PackageLicenseUrl>
+        <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
+        <PackageTags></PackageTags>
+        <PackageOutputPath>$(MSBuildThisFileDirectory)</PackageOutputPath>
+        <AllowedOutputExtensionsInPackageBuildOutputFolder>.pdb;$(AllowedOutputExtensionsInPackageBuildOutputFolder)</AllowedOutputExtensionsInPackageBuildOutputFolder>
+    </PropertyGroup>
   
 </Project>

--- a/Projects/OpenTK.Android/OpenTK.Android.csproj
+++ b/Projects/OpenTK.Android/OpenTK.Android.csproj
@@ -71,7 +71,7 @@
         <PackageLicenseUrl>https://raw.githubusercontent.com/mono/opentk/main/Documentation/License.txt</PackageLicenseUrl>
         <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
         <PackageTags></PackageTags>
-        <PackageOutputPath>$(MSBuildThisFileDirectory)</PackageOutputPath>
+        <PackageOutputPath>$(MSBuildThisFileDirectory)..\..\</PackageOutputPath>
         <AllowedOutputExtensionsInPackageBuildOutputFolder>.pdb;$(AllowedOutputExtensionsInPackageBuildOutputFolder)</AllowedOutputExtensionsInPackageBuildOutputFolder>
     </PropertyGroup>
   

--- a/SignList.xml
+++ b/SignList.xml
@@ -1,0 +1,7 @@
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+
+   <ItemGroup>
+     <FirstParty Include="OpenTK-1.0.*" />
+   </ItemGroup>
+
+ </Project>

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -78,3 +78,12 @@ stages:
         inputs:
           artifactName: 'nuget'
           pathtoPublish: $(Build.ArtifactStagingDirectory)
+
+  - stage: Publish
+    dependsOn: Test
+    condition: eq(variables['System.TeamProject'], 'devdiv') # only sign the packages when running on Windows, and using the private server which has the certificates
+    jobs:
+    - template: sign-artifacts/jobs/v2.yml@internal-templates
+      parameters:
+        signListPath: 'SignList.xml'
+        condition: startsWith(variables['Build.SourceBranch'], 'refs/tags/')

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -80,7 +80,7 @@ stages:
           pathtoPublish: $(Build.ArtifactStagingDirectory)
 
   - stage: Publish
-    dependsOn: Test
+    dependsOn: Build
     condition: eq(variables['System.TeamProject'], 'devdiv') # only sign the packages when running on Windows, and using the private server which has the certificates
     jobs:
     - template: sign-artifacts/jobs/v2.yml@internal-templates

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,7 +1,7 @@
 trigger:
   branches:
     include:
-      - master
+      - main
       - refs/tags/*
 resources:
   repositories:
@@ -14,12 +14,18 @@ variables:
   - group: Xamarin-Secrets
   - name: Configuration
     value: Release
-  DotNetVersion: 6.0.100-preview.1.21103.13
-  DotNet.Cli.Telemetry.OptOut: true
-  Android.Msi: https://dl.internalx.com/vsts-devdiv/Xamarin.Android/public/net6/4451481/master/05bb8e0eae11ae6a73838b13cf91ee2433169dff/Microsoft.NET.Workload.Android.11.0.200.85.msi
-  Android.Pkg: https://dl.internalx.com/vsts-devdiv/Xamarin.Android/public/net6/4451481/master/05bb8e0eae11ae6a73838b13cf91ee2433169dff/Microsoft.NET.Workload.Android-11.0.200-ci.master.85.pkg
-  iOS.Msi: https://bosstoragemirror.azureedge.net/wrench/main/f01fde5cd9a7ffffcdc8d241200c35988700fa00/4449408/package/Microsoft.NET.Workload.iOS.14.3.100-ci.main.1079.msi
-  iOS.Pkg: https://bosstoragemirror.azureedge.net/wrench/main/f01fde5cd9a7ffffcdc8d241200c35988700fa00/4449408/package/notarized/Microsoft.iOS.Bundle.14.3.100-ci.main.1079.pkg
+  - name: DotNetVersion
+    value: 6.0.100-preview.1.21103.13
+  - name: DotNet.Cli.Telemetry.OptOut
+    value: true
+  - name: Android.Msi
+    value: https://dl.internalx.com/vsts-devdiv/Xamarin.Android/public/net6/4451481/master/05bb8e0eae11ae6a73838b13cf91ee2433169dff/Microsoft.NET.Workload.Android.11.0.200.85.msi
+  - name: Android.Pkg
+    value: https://dl.internalx.com/vsts-devdiv/Xamarin.Android/public/net6/4451481/master/05bb8e0eae11ae6a73838b13cf91ee2433169dff/Microsoft.NET.Workload.Android-11.0.200-ci.master.85.pkg
+  - name: iOS.Msi
+    value: https://bosstoragemirror.azureedge.net/wrench/main/f01fde5cd9a7ffffcdc8d241200c35988700fa00/4449408/package/Microsoft.NET.Workload.iOS.14.3.100-ci.main.1079.msi
+  - name: iOS.Pkg
+    value: https://bosstoragemirror.azureedge.net/wrench/main/f01fde5cd9a7ffffcdc8d241200c35988700fa00/4449408/package/notarized/Microsoft.iOS.Bundle.14.3.100-ci.main.1079.pkg
 
 stages:
   - stage: Build

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -61,7 +61,7 @@ stages:
       - task: CopyFiles@2
         displayName: Copy nupkg
         inputs:
-          contents: 'Projects\OpenTK.Android\*.nupkg'
+          contents: '*.nupkg'
           targetFolder: $(Build.ArtifactStagingDirectory)
       - task: CopyFiles@2
         displayName: Copy SignList

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -52,5 +52,29 @@ stages:
       - powershell: |
           & dotnet build Projects\OpenTK.Android\OpenTK.Android.csproj -c Debug   -bl:$(LogDirectory)\Debug.binlog
           & dotnet build Projects\OpenTK.Android\OpenTK.Android.csproj -c Release -bl:$(LogDirectory)\Release.binlog
-        displayName: build samples
+        displayName: build libraries
         errorActionPreference: stop
+      - powershell: |
+          & dotnet pack Projects\OpenTK.Android\OpenTK.Android.csproj -c Release -bl:$(LogDirectory)\PackRelease.binlog
+        displayName: pack NuGet
+        errorActionPreference: stop
+      - task: CopyFiles@2
+        displayName: Copy nupkg
+        inputs:
+          contents: 'Projects\OpenTK.Android\*.nupkg'
+          targetFolder: $(Build.ArtifactStagingDirectory)
+      - task: CopyFiles@2
+        displayName: Copy SignList
+        inputs:
+          contents: 'SignList.xml'
+          targetFolder: $(Build.ArtifactStagingDirectory)
+      - task: CopyFiles@2
+        displayName: Copy snupkg
+        inputs:
+          contents: '*.snupkg'
+          targetFolder: $(Build.ArtifactStagingDirectory)
+      - task: PublishBuildArtifacts@1
+        displayName: upload artifacts
+        inputs:
+          artifactName: 'nuget'
+          pathtoPublish: $(Build.ArtifactStagingDirectory)


### PR DESCRIPTION
This commit will create the new Xamarin.Legacy.OpenTK nuget package. This will replace the
OpenTK-1.0 which is currently shipped with Xamarin.Android.