### PR TITLE
[ci] Use new EO compliant build pools

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -32,7 +32,9 @@ stages:
     jobs:
     - job: buildWindows
       pool:
-        vmImage: windows-latest
+        name: AzurePipelines-EO
+        demands:
+        - ImageOverride -equals AzurePipelinesWindows2019compliant
       variables:
         LogDirectory: $(Build.ArtifactStagingDirectory)\logs
       steps:


### PR DESCRIPTION
Context: https://eng.ms/docs/initiatives/executive-order/executive-order-requirements/executiveorderoncybersecurity/buildinfraops

Migrates to new build pools as part of ongoing security and compliance
efforts.