### PR TITLE
[nuget] use $(PackageLicenseExpression), not $(PackageLicenseUrl)

### DIFF
--- a/OpenTK.props
+++ b/OpenTK.props
@@ -1,5 +1,5 @@
 <Project>
     <PropertyGroup>
-        <_OpenTKNugetVersion>1.0.1</_OpenTKNugetVersion>
+        <_OpenTKNugetVersion>1.0.2</_OpenTKNugetVersion>
     </PropertyGroup>
 </Project>

--- a/Projects/OpenTK.Android/OpenTK.Android.csproj
+++ b/Projects/OpenTK.Android/OpenTK.Android.csproj
@@ -68,7 +68,7 @@
         <Owners>Microsoft, Xamarin</Owners>
         <Copyright>© Microsoft Corporation. All rights reserved.</Copyright>
         <PackageProjectUrl>https://github.com/mono/opentk</PackageProjectUrl>
-        <PackageLicenseUrl>https://raw.githubusercontent.com/mono/opentk/main/Documentation/License.txt</PackageLicenseUrl>
+        <PackageLicenseExpression>MIT AND BSD-3-Clause</PackageLicenseExpression>
         <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
         <PackageTags></PackageTags>
         <PackageOutputPath>$(MSBuildThisFileDirectory)..\..\</PackageOutputPath>


### PR DESCRIPTION
Context: https://docs.microsoft.com/en-us/nuget/reference/nuspec#licenseurl
Context: https://docs.microsoft.com/en-us/nuget/reference/nuspec#license
Context: https://docs.microsoft.com/en-us/dotnet/standard/library-guidance/nuget#important-nuget-package-metadata
Context: https://docs.clearlydefined.io/curation-guidelines

Certain internal Microsoft tools check NuGet license information by
using [ClearlyDefined curated data][0] to determine verified license
information for packages which don't "clearly define" their license.

Unfortunately, a license URL is *not* considered "clearly defined",
likely because it isn't *really* machine readable.  (Just because the
URL contains "MIT" doesn't mean it's *actually* MIT.)

As part of this effort, [NuGet deprecated][1] the [`<licenseUrl/>`][2]
element, and MSBuild deprecated the [`$(PackageLicenseUrl)`][3]
MSBuild property.  The NuGet [`<license/>`][4] element or
[`$(PackageLicenseExpression)` MSBuild property][5] should be used.

Replace `$(PackageLicenseUrl)` with `$(PackageLicenseExpression)`,
with a value of `MIT AND BSD-3-Clause`.  The value needs to be an
[SPDX identifier][6], and as OpenTK contains both MIT and 3-clause
BSD license text within `Documentation/Licennse.txt`, using the
`AND` expression feels appropriate.

This change should satisfy ClearlyDefined.

[0]: https://github.com/clearlydefined/curated-data/
[1]: https://github.com/NuGet/Home/issues/7509
[2]: https://docs.microsoft.com/en-us/nuget/reference/nuspec#licenseurl
[3]: https://docs.microsoft.com/en-us/nuget/reference/msbuild-targets#pack-target
[4]: https://docs.microsoft.com/en-us/nuget/reference/nuspec#license
[5]: https://docs.microsoft.com/en-us/nuget/reference/msbuild-targets#packing-a-license-expression-or-a-license-file
[6]: https://spdx.org/licenses/