### PR TITLE
Enable CodeQL with TSA

### DIFF
--- a/.config/tsaoptions.json
+++ b/.config/tsaoptions.json
@@ -1,0 +1,10 @@
+{
+    "instanceUrl": "https://devdiv.visualstudio.com/",
+    "template": "TFSDEVDIV",
+    "projectName": "DEVDIV",
+    "areaPath": "DevDiv\\mono",
+    "iterationPath": "DevDiv",
+    "notificationAliases": [ "runtimerepo-infra@microsoft.com" ],
+    "repositoryName": "opentk",
+    "codebaseName": "opentk"
+}

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -26,6 +26,10 @@ variables:
     value: https://bosstoragemirror.azureedge.net/wrench/main/f01fde5cd9a7ffffcdc8d241200c35988700fa00/4449408/package/Microsoft.NET.Workload.iOS.14.3.100-ci.main.1079.msi
   - name: iOS.Pkg
     value: https://bosstoragemirror.azureedge.net/wrench/main/f01fde5cd9a7ffffcdc8d241200c35988700fa00/4449408/package/notarized/Microsoft.iOS.Bundle.14.3.100-ci.main.1079.pkg
+  - name: Codeql.Enabled
+    value: True
+  - name: Codeql.TSAEnabled
+    value: True
 
 stages:
   - stage: Build


### PR DESCRIPTION
CodeQL is a static analysis tool that is able to scan source code to help detect security vulnerabilities. In mono/opentk, there already exists auto-injection of CodeQL's init and finalize tasks within the official default pipeline.

We enable CodeQL directly on the main pipeline as there are relatively few jobs, and because commits are relatively infrequent, there is no need for a separate pipeline to specify a cadence (periods between commits and therefore pipeline builds can be over a weeklong, so if there is no change, there is no need for a new codeql scan)

This PR does the following:
Enables CodeQL
Enable TSA with CodeQL